### PR TITLE
add clij to list of update sites

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -227,6 +227,14 @@ sites:
       structures in images.
     maintainers:
       - "[Jean-Yves Tinevez](https://imagej.net/User:JeanYvesTinevez)"
+      
+  - name: "clij"
+    url: "https://sites.imagej.net/clij/"
+    description: >-
+      GPU-acceleration for ImageJ. See 
+      [documentation](http://clij.github.io/clij-docs)
+    maintainers:
+      - "[Robert Haase](https://imagej.net/User:Haesleinhuepf)"
 
   - name: "Cookbook"
     url: "https://sites.imagej.net/Cookbook/"


### PR DESCRIPTION
Hi @ctrueden,

cool to see how the new list of update sites is managed on github!

This PR suggests adding clij to the list of update sites.

Btw: Happy New Year!

Cheers,
Robert
