### PR TITLE
added CAMDU update site to list

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -195,6 +195,14 @@ sites:
     maintainers:
       - "[David Barry](mailto:david.barry@crick.ac.uk)"
 
+    name: "CAMDU"
+    url: "https://sites.imagej.net/CAMDU/"
+    description: >-
+      Plugins from the [Computing and Advanced Microscopy Development Unit](https://www.warwick.ac.uk/camdu) at the
+      [University of Warwick](https://www.warwick.ac.uk).
+    maintainers:
+      - "[Erick Martins Ratamero](mailto:e.martins-ratamero.1@warwick.ac.uk)"
+
   - name: "CellMotility"
     url: "https://sites.imagej.net/CellMotility/"
     description: >-


### PR DESCRIPTION
Dear Curtis,
we're starting to write some Fiji plugins at CAMDU (https://www.warwick.ac.uk/camdu) and we'd love to have the update site on the list! For the moment, we have a plugin for automating microscope quality control tasks that I am probably moving to 1.0 soon.

Best regards,

Erick

PS: entry already includes id value, given pull request #7.