### PR TITLE
Add ActogramJ

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -60,6 +60,14 @@ sites:
     maintainers:
       - "[Thomas Boudier](https://imagej.net/User:Tboudier)"
 
+  - name: "ActogramJ"
+    id: "ActogramJ"
+    url: "https://romulus.oice.uni-erlangen.de/imagej/updatesites/ActogramJ/"
+    description: >-
+      [ActogramJ](https://bene51.github.io/ActogramJ) is a plugin for analyzing actograms.
+    maintainers:
+    - "[Benjamin Schmid](https://imagej.net/User:Bene)"
+  
   - name: "Angiogenesis"
     id: "Angiogenesis"
     url: "https://sites.imagej.net/Angiogenesis/"


### PR DESCRIPTION
ActogramJ is a plugin for visualizing and analyzing actograms, i.e. activity diagrams. It was intended for actograms from fruit fly experiments performed in the Department of Neurobiology and Genetics in Wuerzburg, but can be used for any actograms. It went public back in 2010, and is still in use in various research groups.
https://bene51.github.io/ActogramJ
https://github.com/bene51/ActogramJ