### PR TITLE
Remove EMBL-CBA update site

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -502,15 +502,6 @@ sites:
     maintainers:
       - "[Virginie Uhlmann](https://imagej.net/User:Vuhlmann)"
 
-  - name: "EMBL-CBA"
-    id: "EMBL-CBA"
-    url: "https://sites.imagej.net/EMBL-CBA/"
-    description: >-
-      Collection of image visualisation, processing, registration and analysis tools.
-    maintainers:
-      - "[Christian Tischer](mailto:tischitischer@gmail.com)"
-      - "[EMBL-CBA](mailto:image-analysis-support@embl.de)"
-
   - name: "EpiGraph"
     id: "Pedgomgal1"
     url: "https://sites.imagej.net/Pedgomgal1/"


### PR DESCRIPTION
As discussed some time ago in the Fiji gitter channel, I split the EMBL-CBA update site into several "small" updates sites.
Thus this should be removed now (also because it ships old BDV versions that now would break everything).
