### PR TITLE
add MasksfromRois update site

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -1155,11 +1155,11 @@ sites:
     maintainers:
       - "[Hadrien Mary](https://imagej.net/User:Hadim)"
 
-    name: "Mask(s) from ROI(s)"
+    name: "Masks from ROIs"
     id: "Masks-from-Rois"
     url: "https://sites.imagej.net/MasksfromRois/"
     description: >-
-      Add the command "Mask(s) from Roi(s)" to Edit > Selection.
+      Add the command Mask(s) from Roi(s) to Edit > Selection.
       Generate mask images (0/255) from Rois in the RoiManager. Compatible with image-stacks too.
       Ideal for the generation of ground-truth segmentation masks.
     maintainers:

--- a/sites.yml
+++ b/sites.yml
@@ -1155,7 +1155,7 @@ sites:
     maintainers:
       - "[Hadrien Mary](https://imagej.net/User:Hadim)"
 
-    name: "Masks from ROIs"
+  - name: "Masks from ROIs"
     id: "Masks-from-Rois"
     url: "https://sites.imagej.net/MasksfromRois/"
     description: >-

--- a/sites.yml
+++ b/sites.yml
@@ -1155,6 +1155,16 @@ sites:
     maintainers:
       - "[Hadrien Mary](https://imagej.net/User:Hadim)"
 
+    name: "Mask(s) from ROI(s)"
+    id: "Masks-from-Rois"
+    url: "https://sites.imagej.net/MasksfromRois/"
+    description: >-
+      Add the command "Mask(s) from Roi(s)" to Edit > Selection.
+      Generate mask images (0/255) from Rois in the RoiManager. Compatible with image-stacks too.
+      Ideal for the generation of ground-truth segmentation masks.
+    maintainers:
+      - "[Laurent Thomas](https://imagej.net/User:Lthomas)"
+
   - name: "Mastodon"
     id: "Mastodon-jungle"
     url: "https://sites.imagej.net/Mastodon-jungle/"


### PR DESCRIPTION
I also created an associated plugin page https://imagej.github.io/plugins/MasksFromRois (I have to fix the image though)

As a side note, the readme for the list-of-update-sites repo states
*Before adding a new site please create a page on the Wiki (https://imagej.net/YOUR_UPDATE_SITE_NAME) describing the content of your update site!*

Should it be updated to rather advice to create a page at
https://github.com/imagej/imagej.github.io/tree/main/_pages/plugins/  ?