### PR TITLE
Remove deprecated GDSC-SMLM site

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -857,17 +857,6 @@ sites:
     maintainers:
       - "[Alex Herbert](mailto:a.herbert@sussex.ac.uk)"
 
-  - name: "GDSC-SMLM"
-    id: "GDSC-SMLM"
-    url: "https://sites.imagej.net/GDSC-SMLM/"
-    description: >-
-      Tools for Single Molecule Light Microscopy (SMLM). This version has been
-      superceded by GDSC-SMLM2; the two versions cannot be used together.
-      The original [user manual](http://www.sussex.ac.uk/gdsc/intranet/pdfs/SMLM.pdf)
-      is available.
-    maintainers:
-      - "[Alex Herbert](mailto:a.herbert@sussex.ac.uk)"
-
   - name: "GDSC-SMLM2"
     id: "GDSC-SMLM2"
     url: "https://sites.imagej.net/GDSC-SMLM2/"


### PR DESCRIPTION
The GSDC-SMLM site can be removed.

The site contains code that has not been maintained since 2016. It cannot be run alongside the GDSC or GDSC-SMLM2 site. There is no Wiki page for the update site. Users should update to GDSC-SMLM2 which is currently maintained, has a wiki page, online user documentation and is compatible with the GDSC site.

Any users who require the legacy functionality in GDSC-SMLM can contact me and I will tell them how to add the site manually.
