### PR TITLE
Update url of the TomancakLab update site

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -2240,13 +2240,14 @@ sites:
       - "[Benoit Aigouy](mailto:tissue.analyser@gmail.com)"
 
   - name: "TomancakLab"
-    id: "Ulman2"
-    url: "https://sites.imagej.net/Ulman2/"
+    id: "TomancakLab"
+    url: "https://sites.imagej.net/TomancakLab/"
     description: >-
       A couple of Fiji scripts to ease daily evo-devo image analysis life, from
       Tomancak lab.
     maintainers:
       - "[Vladimír Ulman](mailto:ulman@mpi-cbg.de)"
+      - "[Matthias Arzt](https://imagej.net/people/maarzt)"
 
   - name: "TrackMate-Cellpose"
     id: "TrackMate-Cellpose"


### PR DESCRIPTION
@xulman (the owner of the previous update site) and I agreed that we would like to change the TomancakLab update site to https://sites.imagej.net/Tomancak

The content of both update sites is currently identical, except that there is a newer version of mastodon-tomancak.jar on the new update site. Bot @xulman and I will maintain the new update site.