### PR TITLE
List micron.ox.ac.uk mirrors of the imagej, fiji, and java-8 update sites

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -39,6 +39,33 @@ sites:
     maintainers:
       - "[ImageJ2 and Fiji developers](https://imagej.net/people)"
 
+  - name: "ImageJ (Europe mirror)"
+    id: "ImageJ-micron.ox.ac.uk"
+    url: "https://update.imagej.net/"
+    description: >-
+      European mirror for the ImageJ update site.  Replace the ImageJ
+      update site with this one for faster updates in Europe.
+    maintainers:
+      - "[ImageJ2 developers](https://imagej.net/people#imagej2)"
+
+  - name: "Fiji (Europe mirror)"
+    id: "Fiji-micron.ox.ac.uk"
+    url: "https://update.fiji.sc/"
+    description: >-
+      European mirror for the Fiji update site.  Replace the Fiji
+      update site with this one for faster updates in Europe.
+    maintainers:
+      - "[Fiji developers](https://imagej.net/people#fiji)"
+
+  - name: "Java-8 (Europe mirror)"
+    id: "Java-8-micron.ox.ac.uk"
+    url: "https://sites.imagej.net/Java-8/"
+    description: >-
+      European mirror for the Java-8 update site.  Replace the Java-8
+      update site with this one for faster updates in Europe.
+    maintainers:
+      - "[ImageJ2 and Fiji developers](https://imagej.net/people)"
+
   - name: "2015-Conference"
     id: "2015-Conference"
     url: "https://sites.imagej.net/2015-Conference/"

--- a/sites.yml
+++ b/sites.yml
@@ -41,7 +41,7 @@ sites:
 
   - name: "ImageJ (Europe mirror)"
     id: "ImageJ-micron.ox.ac.uk"
-    url: "https://update.imagej.net/"
+    url: "https://downloads.micron.ox.ac.uk/fiji_update/mirrors/imagej/"
     description: >-
       European mirror for the ImageJ update site.  Replace the ImageJ
       update site with this one for faster updates in Europe.
@@ -50,7 +50,7 @@ sites:
 
   - name: "Fiji (Europe mirror)"
     id: "Fiji-micron.ox.ac.uk"
-    url: "https://update.fiji.sc/"
+    url: "https://downloads.micron.ox.ac.uk/fiji_update/mirrors/fiji/"
     description: >-
       European mirror for the Fiji update site.  Replace the Fiji
       update site with this one for faster updates in Europe.
@@ -59,7 +59,7 @@ sites:
 
   - name: "Java-8 (Europe mirror)"
     id: "Java-8-micron.ox.ac.uk"
-    url: "https://sites.imagej.net/Java-8/"
+    url: "https://downloads.micron.ox.ac.uk/fiji_update/mirrors/java-8/"
     description: >-
       European mirror for the Java-8 update site.  Replace the Java-8
       update site with this one for faster updates in Europe.


### PR DESCRIPTION
Add the Micron Oxford mirrors to the list of update sites. As proposed (but not discussed) in https://forum.image.sc/t/listing-update-sites-mirrors/70289