### PR TITLE
Add the TrackMate-Pairing plugin.

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -2455,10 +2455,11 @@ sites:
     id: "TrackMate-Pairing"
     url: "https://sites.imagej.net/TrackMate-Pairing"
     description: >-
-      Contains a tool that allows pairing together two TrackMate files, based on
-      several distance metrics from the tracks of one file versus the tracks of
-      another filer. This is used mainly to study how the distance of objects 
-      detected in two different channels evolve over time.
+      Contains a tool that allows for pairing together two TrackMate files, based on
+      several distance metrics. It builds pairs taken from the tracks of one file 
+      and the tracks of a second file. 
+      This is used mainly to study how the distance of objects detected in two 
+      different channels evolve over time.
     maintainers:
       - "[Jean-Yves Tinevez](https://imagej.net/people/tinevez)"
 

--- a/sites.yml
+++ b/sites.yml
@@ -2451,6 +2451,17 @@ sites:
     maintainers:
       - "[Varun Kapoor](https://imagej.net/people/kapoorlab)"
 
+  - name: "TrackMate-Pairing"
+    id: "TrackMate-Pairing"
+    url: "https://sites.imagej.net/TrackMate-Pairing"
+    description: >-
+      Contains a tool that allows pairing together two TrackMate files, based on
+      several distance metrics from the tracks of one file versus the tracks of
+      another filer. This is used mainly to study how the distance of objects 
+      detected in two different channels evolve over time.
+    maintainers:
+      - "[Jean-Yves Tinevez](https://imagej.net/people/tinevez)"
+
   - name: "TrackMate-StarDist"
     id: "TrackMate-StarDist"
     url: "https://sites.imagej.net/TrackMate-StarDist"


### PR DESCRIPTION
Contains a tool that allows pairing together two TrackMate files, based on several distance metrics from the tracks of one file versus the tracks of another file. This is used mainly to study how the distance of objects detected in two different channels evolve over time.
