### PR TITLE
Add SciJava Ops update site

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -2191,7 +2191,7 @@ sites:
     id: "scijava-ops"
     url: "https://sites.imagej.net/scijava-ops/"
     description: >-
-      A framework for extensible algorithm execution. See source
+      A framework for extensible algorithm execution. REQUIRES JAVA 11+. See source
       [on GitHub](https://github.com/scijava/scijava).
     maintainers:
       - "[Gabriel Selzer](https://imagej.net/people/gselzer)"

--- a/sites.yml
+++ b/sites.yml
@@ -2187,6 +2187,17 @@ sites:
     maintainers:
       - "[Hadrien Mary](https://imagej.net/people/hadim)"
 
+  - name: "Scijava Ops"
+    id: "scijava-ops"
+    url: "https://sites.imagej.net/scijava-ops/"
+    description: >-
+      A framework for extensible algorithm execution. See source
+      [on GitHub](https://github.com/scijava/scijava).
+    maintainers:
+      - "[Gabriel Selzer](https://imagej.net/people/gselzer)"
+      - "[Curtis Rueden](https://imagej.net/people/ctrueden)"
+      - "[Mark Hiner](https://imagej.net/people/hinerm)"
+
   - name: "sciview"
     id: "sciview"
     url: "https://sites.imagej.net/sciview/"

--- a/sites.yml
+++ b/sites.yml
@@ -2187,7 +2187,7 @@ sites:
     maintainers:
       - "[Hadrien Mary](https://imagej.net/people/hadim)"
 
-  - name: "Scijava Ops"
+  - name: "SciJava Ops"
     id: "scijava-ops"
     url: "https://sites.imagej.net/scijava-ops/"
     description: >-


### PR DESCRIPTION
This PR adds the SciJava Ops update site to the main list.

