### PR TITLE
Add Mastodon-Tomancak to sites.yml

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -1520,7 +1520,20 @@ sites:
       on steroids.
     maintainers:
       - "[Tobias Pietzsch](https://imagej.net/people/tpietzsch)"
-      - "[Jean-Yves Tinevez](https://imagej.net/people/tinevez)"
+      - "[Jean-Yves Tinevez](https://imagej.net/people/tinevez)"      
+
+  - name: "Mastodon-DeepLineage"
+    id: "Mastodon-DeepLineage"
+    url: "https://sites.imagej.net/Mastodon-DeepLineage/"
+    description: >-
+      [Mastodon-DeepLineage](https://github.com/mastodon-sc/mastodon-deep-lineage)
+      provides an extension for the Mastodon plugin and can only be used in conjunction
+      with it. Mastodon allows tracking cell lineages in 3D+t images.
+      Mastodon-DeepLineage extends this with a collection of tools to analyse
+      lineages of tracked objects.
+    maintainers: 
+      - "[Stefan Hahmann](https://imagej.net/people/stefanhahmann)"
+      - "[Matthias Arzt](https://imagej.net/people/maarzt)"
 
   - name: "Mastodon-Tomancak"
     id: "Mastodon-Tomancak"
@@ -1535,20 +1548,6 @@ sites:
       - "[Matthias Arzt](https://imagej.net/people/maarzt)"
       - "[Stefan Hahmann](https://imagej.net/people/stefanhahmann)"
       - "[Vladimír Ulman](https://imagej.net/people/xulman)"
-      
-
-  - name: "Mastodon-DeepLineage"
-    id: "Mastodon-DeepLineage"
-    url: "https://sites.imagej.net/Mastodon-DeepLineage/"
-    description: >-
-      [Mastodon-DeepLineage](https://github.com/mastodon-sc/mastodon-deep-lineage)
-      provides an extension for the Mastodon plugin and can only be used in conjunction
-      with it. Mastodon allows tracking cell lineages in 3D+t images.
-      Mastodon-DeepLineage extends this with a collection of tools to analyse
-      lineages of tracked objects.
-    maintainers: 
-      - "[Stefan Hahmann](https://imagej.net/people/stefanhahmann)"
-      - "[Matthias Arzt](https://imagej.net/people/maarzt)"
 
   - name: "Mcat"
     id: "Mcat"

--- a/sites.yml
+++ b/sites.yml
@@ -1522,17 +1522,33 @@ sites:
       - "[Tobias Pietzsch](https://imagej.net/people/tpietzsch)"
       - "[Jean-Yves Tinevez](https://imagej.net/people/tinevez)"
 
+  - name: "Mastodon-Tomancak"
+    id: "Mastodon-Tomancak"
+    url: "https://sites.imagej.net/Mastodon-Tomancak/"
+    description: >-
+      [Mastodon-Tomancak](https://github.com/mastodon-sc/mastodon) provides extensions 
+      for the Mastodon plugin and can only be used in conjunction with it.
+      Mastodon allows tracking cell lineages in 3D+t images.
+      Mastodon-Tomancak extends this with a collection of tools to edit, analyse and visualise
+      lineages of tracked objects.
+    maintainers:
+      - "[Matthias Arzt](https://imagej.net/people/maarzt)"
+      - "[Stefan Hahmann](https://imagej.net/people/stefanhahmann)"
+      - "[Vladimír Ulman](https://imagej.net/people/xulman)"
+      
+
   - name: "Mastodon-DeepLineage"
     id: "Mastodon-DeepLineage"
     url: "https://sites.imagej.net/Mastodon-DeepLineage/"
     description: >-
       [Mastodon-DeepLineage](https://github.com/mastodon-sc/mastodon-deep-lineage)
-      is an extension for the Mastodon plugin and can only be used in conjunction
-      with it. Mastodon allows track cell lineages in 3D+t images.
+      provides an extension for the Mastodon plugin and can only be used in conjunction
+      with it. Mastodon allows tracking cell lineages in 3D+t images.
       Mastodon-DeepLineage extends this with a collection of tools to analyse
       lineages of tracked objects.
-    maintainers:
+    maintainers: 
       - "[Stefan Hahmann](https://imagej.net/people/stefanhahmann)"
+      - "[Matthias Arzt](https://imagej.net/people/maarzt)"
 
   - name: "Mcat"
     id: "Mcat"


### PR DESCRIPTION
This PR adds Mastodon-Tomancak as an update site to the listed update sites. It includes a small description for it.