### PR TITLE
Update description of CellTracking Challenge Update site

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -446,8 +446,11 @@ sites:
     id: "Ulman"
     url: "https://sites.imagej.net/Ulman/"
     description: >-
-      Implementation of measures and front-end plugins used in and related to
+      Implementation of measures and front-end FIJI plugins used in and related to
       the [Cell Tracking Challenge](http://www.celltrackingchallenge.net).
+      It also provides an extension for importing, editing and exporting 
+      the results of the CellTrackingChallenge, which can be used in 
+      conjunction with the Mastodon plugin.
     maintainers:
       - "[Vladimír Ulman](mailto:ulman@mpi-cbg.de)"
 

--- a/sites.yml
+++ b/sites.yml
@@ -446,7 +446,7 @@ sites:
     id: "Ulman"
     url: "https://sites.imagej.net/Ulman/"
     description: >-
-      Implementation of measures and front-end FIJI plugins used in and related to
+      Implementation of measures and front-end Fiji plugins used in and related to
       the [Cell Tracking Challenge](http://www.celltrackingchallenge.net).
       It also provides an extension for importing, editing and exporting 
       the results of the CellTrackingChallenge, which can be used in 
@@ -1001,7 +1001,7 @@ sites:
     url: "https://sites.imagej.net/GutAnalysisToolbox/"
     description: >-
       [Gut Analysis Toolbox](https://imagej.net/plugins/gut-analysis-toolbox) enables semi-automated analysis of
-      the neuronal and glial distribution within the gut wall in 2D. It uses a combination of FIJI macros, StarDist
+      the neuronal and glial distribution within the gut wall in 2D. It uses a combination of Fiji macros, StarDist
       and deepImageJ for automated segmentation. The primary focus is on characterising the enteric nervous system.
       The aim is to expand the analysis to other celltypes within the gut and enable 3D analysis.
     maintainers:
@@ -1188,7 +1188,7 @@ sites:
     description: >-
       Imaging_FCS 1.491 is a basic ImageJ plugin to calculate and view
       spatio-temporal correlation functions from 16 bit gray tiff stack files.
-      It was written under FIJI (ImageJ 1.51f; Java 1.8.0_102) and requires
+      It was written under Fiji (ImageJ 1.51f; Java 1.8.0_102) and requires
       Imagescience for statistics (simulator) and Apache Poi for file reading
       and writing.
     maintainers:
@@ -2295,7 +2295,7 @@ sites:
       ScientiFig is a tool to build publication-ready scientific figures
       similar to FigureJ from the IBMP-CNRS site. This version of SF is
       deprecated. It must be used in combination with the 'Fiji-Legacy' update
-      site (on old FIJI systems still using java 6). Note also that this
+      site (on old Fiji systems still using java 6). Note also that this
       version of SF is not compatible with 'Tissue Analyser'.
     maintainers:
       - "[Benoit Aigouy](mailto:scientifig@gmail.com)"


### PR DESCRIPTION
This PR adds a mention of the Mastodon plugin in the description of the CellTrackingChallenge Update Site so that it would be found in the list of Update Sites, when looking for 'Mastodon'