### PR TITLE
Added SCIF confocal simulator to list of update sites

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -2317,6 +2317,14 @@ sites:
     maintainers:
       - "[Benoit Aigouy](mailto:scientifig@gmail.com)"
 
+  - name: "SCiF Confocal Simulator"
+    id: "SCIF-Confocal-Simulator"
+    url: "https://sites.imagej.net/SCiF_ConfocalSimulator/"
+    description: >-
+      A laser scanning confocal simulator.
+    maintainers:
+      - "[Gert-Jan Kremers](mailto:g.kremers@erasmusmc.nl)"
+
   - name: "Scijava Jupyter Kernel"
     id: "Scijava-jupyter-kernel"
     url: "https://sites.imagej.net/Scijava-jupyter-kernel/"


### PR DESCRIPTION
We would like to add SCIF confocal simulator to the list of update sites.

Thanks in advance

Johan Slotman and Gert-Jan Kremers