### PR TITLE
Changed the FAST-HIPPOS URL to lowercase in sites.yml

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -844,7 +844,7 @@ sites:
     id: "FAST-HIPPOS"
     url: "https://sites.imagej.net/FAST-HIPPOS/"
     description: >-
-      [FAST-HIPPOS](https://imagej.net/plugins/FAST-HIPPOS) (FLIM Analysis of
+      [FAST-HIPPOS](https://imagej.net/plugins/fast-hippos) (FLIM Analysis of
       Single-cell Traces for Hit Identification of Phenotypes in Pooled Optical
       Screening) is a collection of macros to analyze time-lapse live-cell (FLIM)
       data, and to automatically identify hit cells and save their microscope stage


### PR DESCRIPTION
Upper case is automatically changed into lowercase if you enter it in the browser, but apparently not as a link, leading to a 404 error.