### PR TITLE
Add 3D Objects Counter+ update site

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -123,6 +123,20 @@ sites:
     maintainers:
       - "[Thomas Boudier](https://imagej.net/people/mcib3d)"
 
+  - name: "3D Objects Counter+"
+    id: "3DObjectsCounterPlus"
+    url: "https://sites.imagej.net/3DObjectsCounterPlus/"
+    description: >-
+      [3D Objects Counter+](https://github.com/Jay2owe/3DObjectsCounterPlus)
+      is a Fiji/ImageJ plugin for counting and measuring thresholded 3D
+      objects in image stacks. It extends the native 3D Objects Counter
+      workflow with fixed min/max filters for volume, sphericity, compactness,
+      elongation, surface area, Feret diameter, and intensity, while keeping
+      familiar threshold, size, map, statistics, measurement redirect, macro,
+      and Java API workflows.
+    maintainers:
+      - "[Jamie Malcolm](https://github.com/Jay2owe)"
+
   - name: "3Dscript"
     id: "3Dscript"
     url: "https://romulus.oice.uni-erlangen.de/updatesite/"


### PR DESCRIPTION
Summary:
- Add the 3D Objects Counter+ update site to sites.yml.
- Verified the update site is live at https://sites.imagej.net/3DObjectsCounterPlus/ and db.xml.gz contains plugins/3D_Objects_Counter_Plus-0.1.0.jar.

Validation:
- python -m pip install -r requirements.txt
- python -m yamllint -d relaxed -d "{rules: {key-duplicates: {}}}" sites.yml
- duplicate id check: No duplicate IDs.
- alphabetical order check: Update sites are ordered correctly.
- $env:PYTHONUTF8="1"; python generate-legacy-pages.py
- python -m cram --shell "C:\Program Files\Git\bin\bash.exe" tests: 1 test passed, 0 failed.
- git diff --check
