### PR TITLE
Add FLASH update site

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -1069,6 +1069,21 @@ sites:
       - "[Julian Ferres](mailto:jferres@fi.uba.ar)"
       - "[Franco Giordano](mailto:fgiordano@fi.uba.ar)"
 
+  - name: "FLASH"
+    id: "FLASH"
+    url: "https://sites.imagej.net/FLASH/"
+    description: >-
+      [FLASH](https://github.com/Jay2owe/FLASH) is an ImageJ/Fiji pipeline for
+      batch analysis of multichannel fluorescence microscopy, covering channel
+      setup and ROIs, preprocessing, fluorescence intensity, 3D object
+      segmentation, spatial statistics, and morphometry. It accepts
+      Bio-Formats-readable microscopy files and TIFF stacks, provides
+      interactive parameter previews for thresholding, filtering, StarDist,
+      and Cellpose, and exports quality-control images, per-object and project
+      tables, statistics, run records, and Excel summaries.
+    maintainers:
+      - "[Jamie Malcolm](https://github.com/Jay2owe)"
+
   - name: "FLIMJ"
     id: "FLIMJ"
     url: "https://sites.imagej.net/FLIMJ/"


### PR DESCRIPTION
## Summary

- add the FLASH update site at https://sites.imagej.net/FLASH/
- link the public FLASH repository and maintainer
- describe the supported fluorescence microscopy workflow, inputs, previews, and outputs

## Validation

- python -m yamllint -d relaxed -d {rules: {key-duplicates: {}}} sites.yml
- duplicate ID check from .github/build.sh
- alphabetical order check from .github/build.sh
- python generate-legacy-pages.py
- python -m cram --shell C:\Program Files\Git\bin\bash.exe tests (1 passed)
- git diff --check
