### PR TITLE
Drop the "2-5 channels" claim from the CPC entry

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -571,9 +571,9 @@ sites:
       It classifies objects as coincident when their centroid falls inside a
       segmented object in another channel, and reports the reciprocal
       'contains' relationship for matched objects. CPC works with label images
-      or ROI sets from any segmentation workflow, supports 2-5 channels, uses
-      regex-based image search and grouping for batch operations, and produces
-      pairwise, bidirectional, multi-target colocalization, and batch summaries.
+      or ROI sets from any segmentation workflow, uses regex-based image search
+      and grouping for batch operations, and produces pairwise, bidirectional,
+      multi-target colocalization, and batch summaries.
     maintainers:
       - "[Jamie Malcolm](https://github.com/Jay2owe)"
 


### PR DESCRIPTION
The `Center-Particle-Coincidence` entry says CPC "supports 2-5 channels". That
describes the dialog, not the plugin.

The five was a dialog limit that had leaked into `CPC.run`. It was removed in
CPC 1.5.0, so the same six label images that had always succeeded from a folder
no longer fail from Java, and folder batch processing had never been bound by it
in the first place.

This just removes the clause. Where a slot limit does and does not apply is
detail for the plugin's own documentation, not for the site list, and the rest
of the description is unaffected.

No change to the site id, URL, or maintainer.

Release notes: https://github.com/Jay2owe/CPC/releases/tag/v1.5.0