### PR TITLE
Add Figure Panel Builder update site

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -1037,6 +1037,21 @@ sites:
     maintainers:
       - "Petr Sokolov"
 
+  - name: "Figure Panel Builder"
+    id: "FigurePanelBuilder"
+    url: "https://sites.imagej.net/FigurePanelBuilder/"
+    description: >-
+      [Figure Panel Builder](https://github.com/Jay2owe/FigurePanelBuilder) is a
+      visual ImageJ/Fiji workflow for assembling publication figures from
+      folders and multi-series LIF containers while keeping channel appearance
+      comparable across groups. Representative-section guidance and an
+      all-channel, section-level quantification view support image choice,
+      while a zoomable canvas lets users rotate and flip images and directly
+      edit labels, scale bars, and annotations. It exports PNG, TIFF, editable
+      SVG, full-resolution panels, and auditable metadata and methods records.
+    maintainers:
+      - "[Jamie Malcolm](https://github.com/Jay2owe)"
+
   - name: "Fiji-Cellpose"
     id: "Fiji-Cellpose"
     url: "https://sites.imagej.net/Fiji-Cellpose/"

--- a/sites.yml
+++ b/sites.yml
@@ -1041,7 +1041,7 @@ sites:
     id: "FigurePanelBuilder"
     url: "https://sites.imagej.net/FigurePanelBuilder/"
     description: >-
-      [Figure Panel Builder](https://github.com/Jay2owe/FigurePanelBuilder) is a
+      [Figure Panel Builder](https://imagej.net/plugins/figure-panel-builder) is a
       visual ImageJ/Fiji workflow for assembling publication figures from
       folders and multi-series LIF containers while keeping channel appearance
       comparable across groups. Representative-section guidance and an


### PR DESCRIPTION
Adds the Figure Panel Builder update site to the public registry.

- Update site: https://sites.imagej.net/FigurePanelBuilder/
- Documentation and source: https://github.com/Jay2owe/FigurePanelBuilder
- Maintainer: Jamie Malcolm (@Jay2owe)

Local validation completed successfully:
- YAML lint
- duplicate-ID check
- alphabetical-order check
- legacy HTML/XML generation and parsing
- updater URL cram test (1 passed)
- generated-file and one-file diff checks